### PR TITLE
Build package like bin/BuildPackages.sh after calling prerequisites.sh

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -15,17 +15,34 @@ cd ${PKG_NAME}
 
 ###############################################################################
 #
+
+if [[ -f prerequisites.sh ]]
+then
+  ./prerequisites.sh
+fi
+
 # The next block is borrowed from 
-# https://github.com/gap-packages/example/blob/master/scripts/build_pkg.sh
+# https://github.com/gap-system/gap/blob/master/bin/BuildPackages.sh
 #
 # build this package, if necessary
-if [[ -x autogen.sh ]]; then
-    ./autogen.sh
+#
+# We want to know if this is an autoconf configure script
+# or not, without actually executing it!
+if [[ -f autogen.sh && ! -f configure ]]
+then
+  ./autogen.sh
+fi
+if [[ -f "configure" ]]
+then
+  if grep Autoconf ./configure > /dev/null
+  then
     ./configure --with-gaproot=/home/gap/inst/${GAPDIRNAME}
-    make -j4 V=1
-elif [[ -x configure ]]; then
+  else
     ./configure /home/gap/inst/${GAPDIRNAME}
-    make -j4
+  fi
+  make
+else
+  echo "No building required for $PKG"
 fi
 
 # set up a custom GAP root containing only this package, so that


### PR DESCRIPTION
This may be used to address problems described in #7. I have tested that it works for Semigroups in https://travis-ci.org/gap-packages/gap-docker-pkg-tests-master-devel/jobs/428393254. If the package as a script `prerequisites.sh`, then we will run this script before building the package.